### PR TITLE
No longer send report message for every input message

### DIFF
--- a/topic-frequencies.js
+++ b/topic-frequencies.js
@@ -234,8 +234,6 @@ module.exports = function(RED) {
             
             metricValues[topic].push(value);
 
-            measure();
-
             node.send([null, msg]);
           }
         });


### PR DESCRIPTION
Summary message now only generated on each report interval, not on each input message. 

This change removes the call to measure() within this.on(‘input’), which was previously happening directly before sending each passthrough message, which ensured the node was generating the topic frequency summary message on each and every input message. 

With this change, the node behaves more as expected, in generating report messages on the 1st output only on the configured interval, while allowing input messages to pass through on the 2nd output. 

(Please reject if this change does not reflect the intended behaviour. I wish to report on some very noisy MQTT topics and assumed the current reporting behaviour was a bug rather than by design.)